### PR TITLE
feat: add pydantic.BaseModel variant support, wip

### DIFF
--- a/xsdata_pydantic/base_model/bindings.py
+++ b/xsdata_pydantic/base_model/bindings.py
@@ -1,0 +1,46 @@
+from dataclasses import dataclass
+from dataclasses import field
+from typing import Callable
+
+from xsdata.formats.dataclass import context
+from xsdata.formats.dataclass import parsers
+from xsdata.formats.dataclass import serializers
+from xsdata.utils.constants import return_input
+
+
+class XmlContext(context.XmlContext):
+    """Pydantic dataclasses ready xml context instance."""
+
+    def __init__(
+        self,
+        element_name_generator: Callable = return_input,
+        attribute_name_generator: Callable = return_input,
+    ):
+        super().__init__(
+            element_name_generator, attribute_name_generator, "pydantic_base_model"
+        )
+
+
+@dataclass
+class XmlParser(parsers.XmlParser):
+    context: XmlContext = field(default_factory=XmlContext)
+
+
+@dataclass
+class XmlSerializer(serializers.XmlSerializer):
+    context: XmlContext = field(default_factory=XmlContext)
+
+
+@dataclass
+class JsonParser(parsers.JsonParser):
+    context: XmlContext = field(default_factory=XmlContext)
+
+
+@dataclass
+class JsonSerializer(serializers.JsonSerializer):
+    context: XmlContext = field(default_factory=XmlContext)
+
+
+@dataclass
+class UserXmlParser(parsers.UserXmlParser):
+    context: XmlContext = field(default_factory=XmlContext)

--- a/xsdata_pydantic/base_model/compat.py
+++ b/xsdata_pydantic/base_model/compat.py
@@ -1,0 +1,56 @@
+from dataclasses import MISSING
+from dataclasses import Field
+from dataclasses import field
+from typing import Any
+from typing import Tuple
+from typing import cast
+
+from pydantic import BaseModel
+from pydantic.fields import Undefined
+from pydantic.fields import ModelField
+from xsdata.formats.dataclass.compat import class_types
+
+from xsdata_pydantic.compat import Pydantic
+
+
+def pydantic_field_to_dataclass_field(pydantic_field: ModelField) -> Field:
+    if pydantic_field.default_factory is not None:
+        default_factory: Any = pydantic_field.default_factory
+        default = MISSING
+    else:
+        default_factory = MISSING
+        default = (
+            MISSING
+            if pydantic_field.default in (Undefined, Ellipsis)
+            else pydantic_field.default
+        )
+
+    dataclass_field: Field = field(
+        default=default,
+        default_factory=default_factory,
+        # init=True,
+        # hash=None,
+        # compare=True,
+        metadata=pydantic_field.field_info.extra.get("metadata", {}),
+        kw_only=MISSING,
+    )
+    dataclass_field.name = pydantic_field.name
+    dataclass_field.type = pydantic_field.type_
+    return dataclass_field
+
+
+class PydanticBaseModel(Pydantic):
+    def is_model(self, obj: Any) -> bool:
+        clazz = obj if isinstance(obj, type) else type(obj)
+        if issubclass(clazz, BaseModel):
+            clazz.update_forward_refs()
+            return True
+
+        return False
+
+    def get_fields(self, obj: Any) -> Tuple[Any, ...]:
+        _fields = cast("BaseModel", obj).__fields__.values()
+        return [pydantic_field_to_dataclass_field(field) for field in _fields]
+
+
+class_types.register("pydantic_base_model", PydanticBaseModel())

--- a/xsdata_pydantic/base_model/generator.py
+++ b/xsdata_pydantic/base_model/generator.py
@@ -1,0 +1,69 @@
+from typing import Any, Dict, List
+
+from xsdata.codegen.models import Attr, Class
+from xsdata.formats.dataclass.filters import Filters
+from xsdata.formats.dataclass.generator import DataclassGenerator
+from xsdata.models.config import ExtensionType, GeneratorConfig, OutputFormat
+from xsdata.utils.text import stop_words
+import collections
+
+stop_words.update(("schema", "validate"))
+
+
+class PydanticBaseGenerator(DataclassGenerator):
+    """Python pydantic dataclasses code generator."""
+
+    @classmethod
+    def init_filters(cls, config: GeneratorConfig) -> Filters:
+        return PydanticBaseFilters(config)
+
+
+class PydanticBaseFilters(Filters):
+    @classmethod
+    def build_import_patterns(cls) -> Dict[str, Dict]:
+        patterns = Filters.build_import_patterns()
+        patterns.update(
+            {"pydantic": {"Field": [" = Field("], "BaseModel": ["BaseModel"]}}
+        )
+        return {key: patterns[key] for key in sorted(patterns)}
+
+    @classmethod
+    def filter_metadata(cls, data: Dict) -> Dict:
+        data = super().filter_metadata(data)
+        data.pop("min_length", None)
+        data.pop("max_length", None)
+        return data
+
+    @classmethod
+    def build_class_annotation(cls, fmt: OutputFormat) -> str:
+        # remove the @dataclass decorator
+        return ""
+
+    def field_definition(
+        self,
+        attr: Attr,
+        ns_map: dict,
+        parent_namespace: str | None,
+        parents: list[str],
+    ) -> str:
+        """Return the field definition with any extra metadata."""
+        # updated to use pydantic Field
+        default_value = self.field_default_value(attr, ns_map)
+        metadata = self.field_metadata(attr, parent_namespace, parents)
+
+        kwargs: dict[str, Any] = {}
+        if attr.fixed or attr.is_prohibited:
+            kwargs["init"] = False
+
+        if default_value is not False and not attr.is_prohibited:
+            key = self.FACTORY_KEY if attr.is_factory else self.DEFAULT_KEY
+            kwargs[key] = default_value
+
+        if metadata:
+            kwargs["metadata"] = metadata
+
+        return f"Field({self.format_arguments(kwargs, 4)})"
+
+    def class_bases(self, obj: Class, class_name: str) -> List[str]:
+        # FIXME ... need to dedupe superclasses
+        return super().class_bases(obj, class_name) + ["BaseModel"]

--- a/xsdata_pydantic/hooks/class_type.py
+++ b/xsdata_pydantic/hooks/class_type.py
@@ -1,5 +1,7 @@
 from xsdata.formats.dataclass.compat import class_types
 
+from xsdata_pydantic.base_model.compat import PydanticBaseModel
 from xsdata_pydantic.compat import Pydantic
 
 class_types.register("pydantic", Pydantic())
+class_types.register("pydantic_base_model", PydanticBaseModel())

--- a/xsdata_pydantic/hooks/cli.py
+++ b/xsdata_pydantic/hooks/cli.py
@@ -1,5 +1,7 @@
 from xsdata.codegen.writer import CodeWriter
 
+from xsdata_pydantic.base_model.generator import PydanticBaseGenerator
 from xsdata_pydantic.generator import PydanticGenerator
 
 CodeWriter.register_generator("pydantic", PydanticGenerator)
+CodeWriter.register_generator("pydantic_base_model", PydanticBaseGenerator)


### PR DESCRIPTION
I also found myself wanting a pydantic.BaseModel subclass, as @Nicholas-Schaub requested in #17 ...

This is my stab at it.  I was able to use it to convert a pretty large model, and bind relatively complicated XML data using the generated model, so I don't think it's *too* far off... but perhaps that's naive, given how different it is from the existing patterns.

@tefra, would love to get your input on this.  Obviously, there are some discussions to be had about namespaces and exposing it, but probably best to pause here and see what you think