### PR TITLE
Pydantic v2.0 is incompatible with xsdata-pydantic<= v22.10

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ project_urls =
 [options]
 packages = xsdata_pydantic
 install_requires =
-    pydantic
+    pydantic<2.0
     xsdata>=22.9
 python_requires = >=3.7
 include_package_data = True


### PR DESCRIPTION
Pydantic 2.0 released June 30th and introduced a lot of API changes. The validators API is fully deprecated and means the current version of xsdata-pydantic is incompatible with pydantic 2.0.  This change simply updates the installation requirements until compatibility with the 2.0 api is added. 

I would guess the API update will impact #18 substantially.