### PR TITLE
Specify Any as the return type for field()

### DIFF
--- a/xsdata_pydantic/fields.py
+++ b/xsdata_pydantic/fields.py
@@ -18,7 +18,7 @@ def field(
     default: Any = PydanticUndefined,
     default_factory: Optional[Callable[[], Any]] = PydanticUndefined,
     **kwargs: Any,
-):
+) -> Any:
     return FieldInfo(
         metadata=metadata, default=default, default_factory=default_factory, **kwargs
     )


### PR DESCRIPTION
## 📒 Description

Since `field()` function has no return type annotation the type checkers will infer that it is `FieldInfo` and show errors in the generated classes.

Pydantic solves this by annotating the return type as Any.

## 🔗 What I've Done

Annotate the return type for the `field` function.

## 💬 Comments

> A place to write any comments to the reviewer.

## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
