### PR TITLE
feat: fix double default generation

### DIFF
--- a/tests/fixtures/common.py
+++ b/tests/fixtures/common.py
@@ -17,5 +17,7 @@ class TypeB(TypeA):
 
 
 class TypeC(TypeB):
-    four: List[datetime] = field(default_factory=list, metadata={"format": "%d %B %Y %H:%M"})
+    four: List[datetime] = field(
+        default_factory=list, metadata={"format": "%d %B %Y %H:%M"}
+    )
     any: Optional[object] = field(default=None, metadata={"type": "Wildcard"})

--- a/tests/fixtures/po_2/__init__.py
+++ b/tests/fixtures/po_2/__init__.py
@@ -1,0 +1,9 @@
+from tests.fixtures.po_2.complex_model import (
+    Code,
+    CodeFehlerTyp4,
+)
+
+__all__ = [
+    "Code",
+    "CodeFehlerTyp4",
+]

--- a/tests/fixtures/po_2/complex_model.py
+++ b/tests/fixtures/po_2/complex_model.py
@@ -1,0 +1,109 @@
+from typing import Any, Optional
+
+from pydantic import BaseModel, ConfigDict
+
+from xsdata_pydantic.fields import field
+
+
+class Code(BaseModel):
+    """Der XÖV-Datentyp Code ermöglicht die Übermittlung von Werten, so genannter
+    Codes, aus vordefinierten Codelisten.
+
+    Eine Codeliste ist eine Liste von Codes und der Beschreibung ihrer
+    jeweiligen Bedeutung. Eine entscheidende Eigenschaft des Datentyps
+    ist die Möglichkeit auf differenzierte Weise Bezug zu Codelisten zu
+    nehmen (Code-Typ 1 bis 4). In jedem Fall erlauben die übermittelten
+    Daten eine eindeutige Identifizierung der zugrundeliegenden
+    Codeliste.
+
+    :ivar code: In diesem XML-Element wird der Code einer Codeliste
+        übermittelt.
+    :ivar name: Mit diesem optionalen XML-Element kann die Beschreibung
+        des Codes, wie in der jeweiligen Beschreibungsspalte der
+        Codeliste vorgegeben, übermittelt werden.
+    :ivar list_uri: Mit diesem XML-Attribut wird die Kennung der
+        Codeliste übermittelt, in deren Kontext der jeweilige Code zu
+        interpretieren ist. Die Kennung identifiziert die Codeliste,
+        nicht jedoch deren Version eindeutig. Wird bereits im Rahmen des
+        XÖV-Standards eine Kennung vorgegeben (es handelt sich in diesem
+        Fall um einen Code-Typ 1, 2 oder 3) darf auf eine nochmalige
+        Angabe der Kennung bei der Übermittlung eines Codes verzichtet
+        werden. Aus diesem Grund ist das XML-Attribut listURI zunächst
+        als optional deklariert.
+    :ivar list_version_id: Die konkrete Version der zu nutzenden
+        Codeliste wird mit diesem XML-Attribut übertragen. Analog zum
+        listURI ist die Bestimmung der Version einer Codeliste bei der
+        Übertragung eines Codes zwingend. Die Version kann jedoch
+        ebenfalls bereits im XÖV-Standard festgelegt werden (es handelt
+        sich in diesem Fall um einen Code-Typ 1 oder 2).
+    """
+
+    class Meta:
+        target_namespace = "http://xoev.de/schemata/code/1_0"
+
+    model_config = ConfigDict(defer_build=True)
+    code: str = field(
+        metadata={
+            "type": "Element",
+            "namespace": "",
+            "required": True,
+        }
+    )
+    name: Optional[str] = field(
+        default=None,
+        metadata={
+            "type": "Element",
+            "namespace": "",
+        },
+    )
+    list_uri: Optional[str] = field(
+        default=None,
+        metadata={
+            "name": "listURI",
+            "type": "Attribute",
+        },
+    )
+    list_version_id: Optional[str] = field(
+        default=None,
+        metadata={
+            "name": "listVersionID",
+            "type": "Attribute",
+        },
+    )
+
+
+class CodeFehlerTyp4(Code):
+    """
+    :ivar name: Mit diesem optionalen XML-Element kann die Beschreibung
+        des Codes, wie in der jeweiligen Beschreibungsspalte der
+        Codeliste vorgegeben, übermittelt werden.
+    :ivar list_uri:
+    :ivar list_version_id:
+    """
+
+    class Meta:
+        name = "Code.Fehler.Typ4"
+        target_namespace = "http://www.xjustiz.de"
+
+    model_config = ConfigDict(defer_build=True)
+    name: Any = field(
+        exclude=True,
+        default=None,
+        metadata={
+            "type": "Ignore",
+        },
+    )
+    list_uri: str = field(
+        metadata={
+            "name": "listURI",
+            "type": "Attribute",
+            "required": True,
+        }
+    )
+    list_version_id: str = field(
+        metadata={
+            "name": "listVersionID",
+            "type": "Attribute",
+            "required": True,
+        }
+    )

--- a/tests/fixtures/po_2/complex_model.py
+++ b/tests/fixtures/po_2/complex_model.py
@@ -6,36 +6,12 @@ from xsdata_pydantic.fields import field
 
 
 class Code(BaseModel):
-    """Der XÖV-Datentyp Code ermöglicht die Übermittlung von Werten, so genannter
-    Codes, aus vordefinierten Codelisten.
-
-    Eine Codeliste ist eine Liste von Codes und der Beschreibung ihrer
-    jeweiligen Bedeutung. Eine entscheidende Eigenschaft des Datentyps
-    ist die Möglichkeit auf differenzierte Weise Bezug zu Codelisten zu
-    nehmen (Code-Typ 1 bis 4). In jedem Fall erlauben die übermittelten
-    Daten eine eindeutige Identifizierung der zugrundeliegenden
-    Codeliste.
-
+    """
     :ivar code: In diesem XML-Element wird der Code einer Codeliste
         übermittelt.
-    :ivar name: Mit diesem optionalen XML-Element kann die Beschreibung
-        des Codes, wie in der jeweiligen Beschreibungsspalte der
-        Codeliste vorgegeben, übermittelt werden.
-    :ivar list_uri: Mit diesem XML-Attribut wird die Kennung der
-        Codeliste übermittelt, in deren Kontext der jeweilige Code zu
-        interpretieren ist. Die Kennung identifiziert die Codeliste,
-        nicht jedoch deren Version eindeutig. Wird bereits im Rahmen des
-        XÖV-Standards eine Kennung vorgegeben (es handelt sich in diesem
-        Fall um einen Code-Typ 1, 2 oder 3) darf auf eine nochmalige
-        Angabe der Kennung bei der Übermittlung eines Codes verzichtet
-        werden. Aus diesem Grund ist das XML-Attribut listURI zunächst
-        als optional deklariert.
-    :ivar list_version_id: Die konkrete Version der zu nutzenden
-        Codeliste wird mit diesem XML-Attribut übertragen. Analog zum
-        listURI ist die Bestimmung der Version einer Codeliste bei der
-        Übertragung eines Codes zwingend. Die Version kann jedoch
-        ebenfalls bereits im XÖV-Standard festgelegt werden (es handelt
-        sich in diesem Fall um einen Code-Typ 1 oder 2).
+    :ivar name:
+    :ivar list_uri:
+    :ivar list_version_id:
     """
 
     class Meta:
@@ -73,14 +49,6 @@ class Code(BaseModel):
 
 
 class CodeFehlerTyp4(Code):
-    """
-    :ivar name: Mit diesem optionalen XML-Element kann die Beschreibung
-        des Codes, wie in der jeweiligen Beschreibungsspalte der
-        Codeliste vorgegeben, übermittelt werden.
-    :ivar list_uri:
-    :ivar list_version_id:
-    """
-
     class Meta:
         name = "Code.Fehler.Typ4"
         target_namespace = "http://www.xjustiz.de"

--- a/tests/fixtures/schemas/xsd/xjustiz_0010_cl_allgemein_3_6.xsd
+++ b/tests/fixtures/schemas/xsd/xjustiz_0010_cl_allgemein_3_6.xsd
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:tns="http://www.xjustiz.de"
+           xmlns:xoev-code="http://xoev.de/schemata/code/1_0"
+           targetNamespace="http://www.xjustiz.de"
+           version="3.6.1"
+           elementFormDefault="unqualified"
+           attributeFormDefault="unqualified">
+   <xs:annotation>
+      <xs:appinfo>
+         <standard>
+            <nameLang>Strukturierte Fachdaten für die Kommunikation im elektronischen Rechtsverkehr</nameLang>
+            <nameKurz>XJustiz</nameKurz>
+            <nameTechnisch>xjustiz</nameTechnisch>
+            <kennung>urn:xoev-de:blk-ag-it-standards:standard:xjustiz</kennung>
+            <beschreibung>XJustiz ist der bundesweit einheitliche Standard für den Austausch strukturierter elektronischer Informationen mit der Justiz.</beschreibung>
+         </standard>
+         <versionStandard>
+            <version>3.5.1</version>
+            <beschreibung>XJustiz beschreibt ein standardisiertes Datenaustauschformat für die elektronische Kommunikation innerhalb und mit der Justizverwaltung.</beschreibung>
+            <versionXOEVProfil>1.7.2</versionXOEVProfil>
+            <versionXOEVHandbuch>2.3.1</versionXOEVHandbuch>
+            <versionXGenerator>3.1.1</versionXGenerator>
+            <versionModellierungswerkzeug>19.0 SP3</versionModellierungswerkzeug>
+            <nameModellierungswerkzeug>MagicDraw</nameModellierungswerkzeug>
+         </versionStandard>
+      </xs:appinfo>
+   </xs:annotation>
+   <xs:import schemaLocation="xoev-code.xsd"
+              namespace="http://xoev.de/schemata/code/1_0"/>
+   <xs:complexType name="Code.Fehler.Typ4">
+      <xs:complexContent>
+         <xs:restriction base="xoev-code:Code">
+            <xs:sequence>
+               <xs:element name="code" type="xs:token"/>
+            </xs:sequence>
+            <xs:attribute name="listURI" type="xs:anyURI" use="required"/>
+            <xs:attribute name="listVersionID" type="xs:normalizedString" use="required"/>
+         </xs:restriction>
+      </xs:complexContent>
+   </xs:complexType>
+</xs:schema>

--- a/tests/fixtures/schemas/xsd/xoev-code.xsd
+++ b/tests/fixtures/schemas/xsd/xoev-code.xsd
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:xoev-code="http://xoev.de/schemata/code/1_0"
+           targetNamespace="http://xoev.de/schemata/code/1_0"
+           version="1.0"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified">
+   <xs:complexType name="Code">
+      <xs:annotation>
+         <xs:appinfo>
+            <datentyp>
+               <nameLang>XÖV-Datentyp Code</nameLang>
+               <nameKurz>Code</nameKurz>
+               <nameTechnisch>Code</nameTechnisch>
+               <kennung>urn:xoev-de:kosit:xoev:datentyp:code</kennung>
+               <externeWebsite>http://www.xoev.de/de/code</externeWebsite>
+            </datentyp>
+            <versionDatentyp>
+               <version>1.0</version>
+               <lizenz>Creative Commons Namensnennung - Keine Bearbeitung 4.0 International</lizenz>
+               <bezugsort>http://www.xoev.de/de/bibliothek</bezugsort>
+            </versionDatentyp>
+         </xs:appinfo>
+         <xs:documentation>Der XÖV-Datentyp Code ermöglicht die Übermittlung von Werten, so genannter Codes, aus vordefinierten Codelisten. Eine Codeliste ist eine Liste von Codes und der Beschreibung ihrer jeweiligen Bedeutung. Eine entscheidende Eigenschaft des Datentyps ist die Möglichkeit auf differenzierte Weise Bezug zu Codelisten zu nehmen (Code-Typ 1 bis 4). In jedem Fall erlauben die übermittelten Daten eine eindeutige Identifizierung der zugrundeliegenden Codeliste.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="code" type="xs:token" form="unqualified">
+            <xs:annotation>
+               <xs:documentation>In diesem XML-Element wird der Code einer Codeliste übermittelt.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="name"
+                     minOccurs="0"
+                     type="xs:normalizedString"
+                     form="unqualified">
+            <xs:annotation>
+               <xs:documentation>Mit diesem optionalen XML-Element kann die Beschreibung des Codes, wie in der jeweiligen Beschreibungsspalte der Codeliste vorgegeben, übermittelt werden.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+      <xs:attribute name="listURI" type="xs:anyURI" use="optional">
+         <xs:annotation>
+            <xs:documentation>Mit diesem XML-Attribut wird die Kennung der Codeliste übermittelt, in deren Kontext der jeweilige Code zu interpretieren ist. Die Kennung identifiziert die Codeliste, nicht jedoch deren Version eindeutig. Wird bereits im Rahmen des XÖV-Standards eine Kennung vorgegeben (es handelt sich in diesem Fall um einen Code-Typ 1, 2 oder 3) darf auf eine nochmalige Angabe der Kennung bei der Übermittlung eines Codes verzichtet werden. Aus diesem Grund ist das XML-Attribut listURI zunächst als optional deklariert.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="listVersionID" type="xs:normalizedString" use="optional">
+         <xs:annotation>
+            <xs:documentation>Die konkrete Version der zu nutzenden Codeliste wird mit diesem XML-Attribut übertragen. Analog zum listURI ist die Bestimmung der Version einer Codeliste bei der Übertragung eines Codes zwingend. Die Version kann jedoch ebenfalls bereits im XÖV-Standard festgelegt werden (es handelt sich in diesem Fall um einen Code-Typ 1 oder 2).</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+</xs:schema>

--- a/tests/fixtures/schemas/xsd/xoev-code.xsd
+++ b/tests/fixtures/schemas/xsd/xoev-code.xsd
@@ -21,7 +21,6 @@
                <bezugsort>http://www.xoev.de/de/bibliothek</bezugsort>
             </versionDatentyp>
          </xs:appinfo>
-         <xs:documentation>Der XÖV-Datentyp Code ermöglicht die Übermittlung von Werten, so genannter Codes, aus vordefinierten Codelisten. Eine Codeliste ist eine Liste von Codes und der Beschreibung ihrer jeweiligen Bedeutung. Eine entscheidende Eigenschaft des Datentyps ist die Möglichkeit auf differenzierte Weise Bezug zu Codelisten zu nehmen (Code-Typ 1 bis 4). In jedem Fall erlauben die übermittelten Daten eine eindeutige Identifizierung der zugrundeliegenden Codeliste.</xs:documentation>
       </xs:annotation>
       <xs:sequence>
          <xs:element name="code" type="xs:token" form="unqualified">
@@ -33,20 +32,11 @@
                      minOccurs="0"
                      type="xs:normalizedString"
                      form="unqualified">
-            <xs:annotation>
-               <xs:documentation>Mit diesem optionalen XML-Element kann die Beschreibung des Codes, wie in der jeweiligen Beschreibungsspalte der Codeliste vorgegeben, übermittelt werden.</xs:documentation>
-            </xs:annotation>
          </xs:element>
       </xs:sequence>
       <xs:attribute name="listURI" type="xs:anyURI" use="optional">
-         <xs:annotation>
-            <xs:documentation>Mit diesem XML-Attribut wird die Kennung der Codeliste übermittelt, in deren Kontext der jeweilige Code zu interpretieren ist. Die Kennung identifiziert die Codeliste, nicht jedoch deren Version eindeutig. Wird bereits im Rahmen des XÖV-Standards eine Kennung vorgegeben (es handelt sich in diesem Fall um einen Code-Typ 1, 2 oder 3) darf auf eine nochmalige Angabe der Kennung bei der Übermittlung eines Codes verzichtet werden. Aus diesem Grund ist das XML-Attribut listURI zunächst als optional deklariert.</xs:documentation>
-         </xs:annotation>
       </xs:attribute>
       <xs:attribute name="listVersionID" type="xs:normalizedString" use="optional">
-         <xs:annotation>
-            <xs:documentation>Die konkrete Version der zu nutzenden Codeliste wird mit diesem XML-Attribut übertragen. Analog zum listURI ist die Bestimmung der Version einer Codeliste bei der Übertragung eines Codes zwingend. Die Version kann jedoch ebenfalls bereits im XÖV-Standard festgelegt werden (es handelt sich in diesem Fall um einen Code-Typ 1 oder 2).</xs:documentation>
-         </xs:annotation>
       </xs:attribute>
    </xs:complexType>
 </xs:schema>

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -36,3 +36,25 @@ class PydanticGeneratorTests(FactoryTestCase):
         )
 
         self.assertIsNone(result.exception)
+
+    def test_prohibited_optional_code_field_generation(self):
+        runner = CliRunner()
+        schema = Path(__file__).parent.joinpath("fixtures/schemas/xsd/xjustiz_0010_cl_allgemein_3_6.xsd")
+        os.chdir(Path(__file__).parent.parent)
+
+        result = runner.invoke(
+            cli,
+            [
+                str(schema),
+                "--package",
+                "tests.fixtures.po_2.complex_model",
+                "--structure-style=single-package",
+                "--output",
+                "pydantic",
+                "--config",
+                "tests/fixtures/pydantic.conf.xml",
+            ],
+            catch_exceptions=True,
+        )
+
+        self.assertIsNone(result.exception)

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -39,7 +39,9 @@ class PydanticGeneratorTests(FactoryTestCase):
 
     def test_prohibited_optional_code_field_generation(self):
         runner = CliRunner()
-        schema = Path(__file__).parent.joinpath("fixtures/schemas/xsd/xjustiz_0010_cl_allgemein_3_6.xsd")
+        schema = Path(__file__).parent.joinpath(
+            "fixtures/schemas/xsd/xjustiz_0010_cl_allgemein_3_6.xsd"
+        )
         os.chdir(Path(__file__).parent.parent)
 
         result = runner.invoke(

--- a/xsdata_pydantic/generator.py
+++ b/xsdata_pydantic/generator.py
@@ -46,7 +46,15 @@ class PydanticFilters(Filters):
         result = super().field_definition(obj, attr, parent_namespace)
 
         if attr.is_prohibited:
-            result = result.replace("init=False", "exclude=True, default=None")
+            # If the field is optional and has no other default, the base generator would add default=None.
+            # Prohibited fields are not initialized, so base generator adds init=False.
+            if attr.is_optional and attr.default is None:
+                # Base class already added default=None. Just replace init=False with exclude=True.
+                result = result.replace("init=False", "exclude=True")
+            else:
+                # Base class did NOT add default=None (e.g., field is required or has another default).
+                # Replace init=False with exclude=True and also add default=None for consistency with Pydantic's exclude.
+                result = result.replace("init=False", "exclude=True, default=None")
         elif attr.fixed:
             result = result.replace("init=False", "const=True")
 


### PR DESCRIPTION
Fixing this https://github.com/tefra/xsdata-pydantic/issues/36

## 📒 Description

Fix for Duplicate default=None in Prohibited Fields

This change corrects a bug in how prohibited fields (is_prohibited) are handled, preventing the generator from producing duplicate default=None keyword arguments in the output Pydantic model.
<img width="545" alt="Screenshot 2025-06-12 at 10 51 33" src="https://github.com/user-attachments/assets/28218021-bd5a-4b12-a555-3e0aead1d034" />



Resolves[ #36](https://github.com/tefra/xsdata-pydantic/issues/36)

## 🔗 What I've Done

> Write a description of the steps taken to resolve the issue

## 💬 Comments

> A place to write any comments to the reviewer.

## 🛫 Checklist

- [x] Updated docs
- [x] Added unit-tests
