### PR TITLE
Fix JSON schema generation for pydantic models with XML types

### DIFF
--- a/xsdata_pydantic/compat.py
+++ b/xsdata_pydantic/compat.py
@@ -13,6 +13,7 @@ from xml.etree.ElementTree import QName
 from pydantic import BaseModel
 from pydantic_core import core_schema
 from pydantic_core import PydanticUndefined
+from pydantic_core.core_schema import str_schema
 from xsdata.formats.converter import converter
 from xsdata.formats.dataclass.compat import class_types
 from xsdata.formats.dataclass.compat import Dataclasses
@@ -121,7 +122,10 @@ def set_validator(data_type: Any):
     ) -> core_schema.CoreSchema:
         conv = converter.type_converter(data_type)
         return core_schema.json_or_python_schema(
-            json_schema=core_schema.no_info_plain_validator_function(conv.deserialize),
+            json_schema=core_schema.no_info_plain_validator_function(
+                conv.deserialize,
+                json_schema_input_schema=str_schema(),
+            ),
             python_schema=core_schema.is_instance_schema(data_type),
             serialization=core_schema.plain_serializer_function_ser_schema(
                 conv.serialize


### PR DESCRIPTION
Fixed JSON schema generation for models containing XmlDate, XmlDateTime, XmlTime, XmlDuration, XmlPeriod, QName internal data types.

## 📒 Description

# Fix JSON Schema Generation for XML Data Types

### Problem Description

Models containing internal XML data types (`XmlDateTime`, `XmlDate`, `XmlTime`, `XmlDuration`, `XmlPeriod`, `QName`) cause a `PydanticInvalidForJsonSchema` error when attempting to generate JSON schemas using `model_json_schema()`.

### Example Model

```python
class GenericVersioningEntity(GenericEntity):
    """
    Тип, базовый для сущностей, поддерживающих версии.

    Attributes:
        guid: Глобальный идентификатор в системах Россельхознадзора.
        active: Флаг, определяющий актуальность записи.
        last: Флаг, указывающий на то, что запись является последней в
            истории.
        status: Статус объекта.
        create_date: Дата создания объекта.
        update_date: Дата последнего обновления объекта.
        previous: Идентификатор предыдущей версии объекта.
        next: Идентификатор последующей версии объекта.
    """

    model_config = ConfigDict(defer_build=True)
    guid: Optional[str] = field(
        default=None,
        metadata={
            "type": "Element",
            "namespace": "http://api.vetrf.ru/schema/cdm/base",
            "pattern": r"[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}",
        },
    )
    active: Optional[bool] = field(
        default=None,
        metadata={
            "type": "Element",
            "namespace": "http://api.vetrf.ru/schema/cdm/base",
        },
    )
    last: Optional[bool] = field(
        default=None,
        metadata={
            "type": "Element",
            "namespace": "http://api.vetrf.ru/schema/cdm/base",
        },
    )
    status: Optional[str] = field(
        default=None,
        metadata={
            "type": "Element",
            "namespace": "http://api.vetrf.ru/schema/cdm/base",
            "pattern": r"[1-4][0-9][0-9]",
        },
    )
    create_date: Optional[XmlDateTime] = field(
        default=None,
        metadata={
            "name": "createDate",
            "type": "Element",
            "namespace": "http://api.vetrf.ru/schema/cdm/base",
        },
    )
    update_date: Optional[XmlDateTime] = field(
        default=None,
        metadata={
            "name": "updateDate",
            "type": "Element",
            "namespace": "http://api.vetrf.ru/schema/cdm/base",
        },
    )
    previous: Optional[str] = field(
        default=None,
        metadata={
            "type": "Element",
            "namespace": "http://api.vetrf.ru/schema/cdm/base",
            "pattern": r"[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}",
        },
    )
    next: Optional[str] = field(
        default=None,
        metadata={
            "type": "Element",
            "namespace": "http://api.vetrf.ru/schema/cdm/base",
            "pattern": r"[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}",
        },
    )
```

### Error Reproduction

```python
from pprint import pprint
pprint(GenericVersioningEntity.model_json_schema())
```

## Error Traceback

```
Traceback (most recent call last):
  File "/home/alex/.local/share/JetBrains/Toolbox/apps/pycharm-professional/plugins/python-ce/helpers/pydev/pydevconsole.py", line 364, in runcode
    coro = func()
           ^^^^^^
  File "<input>", line 4, in <module>
  File "/home/alex/programming/vetis_pydantic_types/venv/lib/python3.12/site-packages/pydantic/main.py", line 555, in model_json_schema
    return model_json_schema(
           ^^^^^^^^^^^^^^^^^^
  File "/home/alex/programming/vetis_pydantic_types/venv/lib/python3.12/site-packages/pydantic/json_schema.py", line 2413, in model_json_schema
    return schema_generator_instance.generate(cls.__pydantic_core_schema__, mode=mode)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alex/programming/vetis_pydantic_types/venv/lib/python3.12/site-packages/pydantic/json_schema.py", line 399, in generate
    json_schema: JsonSchemaValue = self.generate_inner(schema)
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alex/programming/vetis_pydantic_types/venv/lib/python3.12/site-packages/pydantic/json_schema.py", line 563, in generate_inner
    json_schema = current_handler(schema)
                  ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alex/programming/vetis_pydantic_types/venv/lib/python3.12/site-packages/pydantic/_internal/_schema_generation_shared.py", line 37, in __call__
    return self.handler(core_schema)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alex/programming/vetis_pydantic_types/venv/lib/python3.12/site-packages/pydantic/json_schema.py", line 541, in new_handler_func
    json_schema = js_modify_function(schema_or_field, current_handler)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alex/programming/vetis_pydantic_types/venv/lib/python3.12/site-packages/pydantic/main.py", line 829, in __get_pydantic_json_schema__
    return handler(core_schema)
           ^^^^^^^^^^^^^^^^^^^^
  File "/home/alex/programming/vetis_pydantic_types/venv/lib/python3.12/site-packages/pydantic/_internal/_schema_generation_shared.py", line 37, in __call__
    return self.handler(core_schema)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alex/programming/vetis_pydantic_types/venv/lib/python3.12/site-packages/pydantic/json_schema.py", line 495, in handler_func
    json_schema = generate_for_schema_type(schema_or_field)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alex/programming/vetis_pydantic_types/venv/lib/python3.12/site-packages/pydantic/json_schema.py", line 1488, in model_schema
    json_schema = self.generate_inner(schema['schema'])
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alex/programming/vetis_pydantic_types/venv/lib/python3.12/site-packages/pydantic/json_schema.py", line 563, in generate_inner
    json_schema = current_handler(schema)
                  ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alex/programming/vetis_pydantic_types/venv/lib/python3.12/site-packages/pydantic/_internal/_schema_generation_shared.py", line 37, in __call__
    return self.handler(core_schema)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alex/programming/vetis_pydantic_types/venv/lib/python3.12/site-packages/pydantic/json_schema.py", line 495, in handler_func
    json_schema = generate_for_schema_type(schema_or_field)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alex/programming/vetis_pydantic_types/venv/lib/python3.12/site-packages/pydantic/json_schema.py", line 1601, in model_fields_schema
    json_schema = self._named_required_fields_schema(named_required_fields)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alex/programming/vetis_pydantic_types/venv/lib/python3.12/site-packages/pydantic/json_schema.py", line 1392, in _named_required_fields_schema
    field_json_schema = self.generate_inner(field).copy()
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alex/programming/vetis_pydantic_types/venv/lib/python3.12/site-packages/pydantic/json_schema.py", line 563, in generate_inner
    json_schema = current_handler(schema)
                  ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alex/programming/vetis_pydantic_types/venv/lib/python3.12/site-packages/pydantic/_internal/_schema_generation_shared.py", line 37, in __call__
    return self.handler(core_schema)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alex/programming/vetis_pydantic_types/venv/lib/python3.12/site-packages/pydantic/json_schema.py", line 495, in handler_func
    json_schema = generate_for_schema_type(schema_or_field)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alex/programming/vetis_pydantic_types/venv/lib/python3.12/site-packages/pydantic/json_schema.py", line 1460, in model_field_schema
    return self.generate_inner(schema['schema'])
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alex/programming/vetis_pydantic_types/venv/lib/python3.12/site-packages/pydantic/json_schema.py", line 563, in generate_inner
    json_schema = current_handler(schema)
                  ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alex/programming/vetis_pydantic_types/venv/lib/python3.12/site-packages/pydantic/_internal/_schema_generation_shared.py", line 37, in __call__
    return self.handler(core_schema)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alex/programming/vetis_pydantic_types/venv/lib/python3.12/site-packages/pydantic/json_schema.py", line 495, in handler_func
    json_schema = generate_for_schema_type(schema_or_field)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alex/programming/vetis_pydantic_types/venv/lib/python3.12/site-packages/pydantic/json_schema.py", line 1109, in default_schema
    json_schema = self.generate_inner(schema['schema'])
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alex/programming/vetis_pydantic_types/venv/lib/python3.12/site-packages/pydantic/json_schema.py", line 563, in generate_inner
    json_schema = current_handler(schema)
                  ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alex/programming/vetis_pydantic_types/venv/lib/python3.12/site-packages/pydantic/_internal/_schema_generation_shared.py", line 37, in __call__
    return self.handler(core_schema)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alex/programming/vetis_pydantic_types/venv/lib/python3.12/site-packages/pydantic/json_schema.py", line 495, in handler_func
    json_schema = generate_for_schema_type(schema_or_field)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alex/programming/vetis_pydantic_types/venv/lib/python3.12/site-packages/pydantic/json_schema.py", line 1179, in nullable_schema
    inner_json_schema = self.generate_inner(schema['schema'])
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alex/programming/vetis_pydantic_types/venv/lib/python3.12/site-packages/pydantic/json_schema.py", line 563, in generate_inner
    json_schema = current_handler(schema)
                  ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alex/programming/vetis_pydantic_types/venv/lib/python3.12/site-packages/pydantic/_internal/_schema_generation_shared.py", line 37, in __call__
    return self.handler(core_schema)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alex/programming/vetis_pydantic_types/venv/lib/python3.12/site-packages/pydantic/json_schema.py", line 495, in handler_func
    json_schema = generate_for_schema_type(schema_or_field)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alex/programming/vetis_pydantic_types/venv/lib/python3.12/site-packages/pydantic/json_schema.py", line 1342, in json_or_python_schema
    return self.generate_inner(schema['json_schema'])
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alex/programming/vetis_pydantic_types/venv/lib/python3.12/site-packages/pydantic/json_schema.py", line 563, in generate_inner
    json_schema = current_handler(schema)
                  ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alex/programming/vetis_pydantic_types/venv/lib/python3.12/site-packages/pydantic/_internal/_schema_generation_shared.py", line 37, in __call__
    return self.handler(core_schema)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alex/programming/vetis_pydantic_types/venv/lib/python3.12/site-packages/pydantic/json_schema.py", line 495, in handler_func
    json_schema = generate_for_schema_type(schema_or_field)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alex/programming/vetis_pydantic_types/venv/lib/python3.12/site-packages/pydantic/json_schema.py", line 1082, in function_plain_schema
    return self.handle_invalid_for_json_schema(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alex/programming/vetis_pydantic_types/venv/lib/python3.12/site-packages/pydantic/json_schema.py", line 2318, in handle_invalid_for_json_schema
    raise PydanticInvalidForJsonSchema(f'Cannot generate a JsonSchema for {error_info}')
pydantic.errors.PydanticInvalidForJsonSchema: Cannot generate a JsonSchema for core_schema.PlainValidatorFunctionSchema ({'type': 'no-info', 'function': <bound method ProxyConverter.deserialize of <xsdata.formats.converter.ProxyConverter object at 0x7487b401ea50>>})
For further information visit https://errors.pydantic.dev/2.11/u/invalid-for-json-schema
```

### Root Cause

The error occurs because XML data types (`XmlDateTime`, `XmlDate`, `XmlTime`, `XmlDuration`, `XmlPeriod`, `QName`) use internal `xsdata.formats.converter.ProxyConverter` functions for serialization/deserialization. Pydantic's JSON schema generator cannot handle `PlainValidatorFunctionSchema` with these converter functions, resulting in a `PydanticInvalidForJsonSchema` exception.

### Solution

Fixed by implementing proper JSON schema handlers for these XML data types.

### Affected Types

- `XmlDate`
- `XmlDateTime` 
- `XmlTime`
- `XmlDuration`
- `XmlPeriod`
- `QName`

## 🔗 What I've Done

Fixed schema generation for models containing XmlDate, XmlDateTime, XmlTime, XmlDuration, XmlPeriod, and QName internal data types by adding str_schema() call for python_schema generation

## 💬 Comments

> A place to write any comments to the reviewer.

## 🛫 Checklist

- [ ] Updated docs
- [ ] Added unit-tests
